### PR TITLE
add check whether snapshot id exists.

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -227,6 +227,9 @@ func (client *AWSClient) DeregisterImages(ctx context.Context, images []*ec2.Ima
 			ImageId: image.ImageId,
 		})
 		for _, d := range image.BlockDeviceMappings {
+			if d.Ebs == nil {
+				continue
+			}
 			client.svcEC2.DeleteSnapshot(&ec2.DeleteSnapshotInput{
 				SnapshotId: d.Ebs.SnapshotId,
 			})


### PR DESCRIPTION
 When ephemeral disk is used,  it will be an error as below. because SnapshotId can not be acquired in Describe Image.

Therefore, I think that it is necessary to add a process to skip Ebs column if it is not in the output result.
