### PR TITLE
Fix not effective region option

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -46,7 +46,7 @@ func NewAWSClient() *AWSClient {
 	sess := session.Must(session.NewSession())
 	return &AWSClient{
 		svcEC2:         ec2.New(sess, aws.NewConfig().WithRegion("ap-northeast-1")),
-		svcEC2Metadata: ec2metadata.New(session.Must(session.NewSession())),
+		svcEC2Metadata: ec2metadata.New(sess),
 	}
 }
 

--- a/aws.go
+++ b/aws.go
@@ -54,8 +54,8 @@ func getRegion(svc EC2MetadataAPI) (string, error) {
 }
 
 // NewSession creates a session.
-func NewAWSSession() *session.Session {
-	return session.Must(session.NewSession())
+func NewAWSSession() (*session.Session, error) {
+	return session.NewSession()
 }
 
 // NewAWSClient creates an AWSClient.

--- a/aws.go
+++ b/aws.go
@@ -38,6 +38,7 @@ type AWS interface {
 type AWSClient struct {
 	svcEC2         ec2iface.EC2API
 	svcEC2Metadata EC2MetadataAPI
+	config         *aws.Config
 }
 
 func getRegion(svc EC2MetadataAPI) (string, error) {
@@ -88,6 +89,7 @@ func NewAWSClient(sess *session.Session, region string) (*AWSClient, error) {
 	return &AWSClient{
 		svcEC2:         ec2.New(sess, config),
 		svcEC2Metadata: svcEC2Metadata,
+		config:         config,
 	}, nil
 }
 

--- a/aws_test.go
+++ b/aws_test.go
@@ -19,11 +19,7 @@ func TestGetRegion(t *testing.T) {
 	mockEC2Metadata.EXPECT().Region().Return("ap-northeast-1", nil)
 	mockEC2Metadata.EXPECT().Available().Return(true)
 
-	client := AWSClient{
-		svcEC2Metadata: mockEC2Metadata,
-	}
-
-	got, err := client.GetRegion()
+	got, err := getRegion(mockEC2Metadata)
 	if err != nil {
 		t.Fatal("Region failed: ", err)
 	}
@@ -41,11 +37,7 @@ func TestGetRegion_EC2Metadata_Unavailable(t *testing.T) {
 	mockEC2Metadata := mock.NewMockEC2MetadataAPI(mockCtrl)
 	mockEC2Metadata.EXPECT().Available().Return(false)
 
-	client := AWSClient{
-		svcEC2Metadata: mockEC2Metadata,
-	}
-
-	_, got := client.GetRegion()
+	_, got := getRegion(mockEC2Metadata)
 
 	want := "program is not running with EC2 Instance or metadata service is not available"
 	if got.Error() != want {

--- a/backup.go
+++ b/backup.go
@@ -15,7 +15,6 @@ import (
 type Backup struct {
 	InstanceID string
 	Name       string
-	Region     string
 	Generation int
 	Service    string
 	CustomTags []Tag
@@ -24,7 +23,7 @@ type Backup struct {
 
 // Tag is key-value formatted metadata for backup
 type Tag struct {
-	Key  string
+	Key   string
 	Value string
 }
 

--- a/cli.go
+++ b/cli.go
@@ -135,21 +135,18 @@ func (c *CLI) run() (int, error) {
 		return ExitCodeOK, nil
 	}
 
+	sess := NewAWSSession()
+	client, err := NewAWSClient(sess, c.flags.region)
+	if err != nil {
+		return ExitCodeAWSError, fmt.Errorf("create aws client failed: %s", err)
+	}
+
 	backup := &Backup{
 		InstanceID: c.flags.instanceID,
-		Region:     c.flags.region,
 		Generation: c.flags.generation,
 		Service:    c.flags.service,
 		CustomTags: c.flags.customTags,
-		Client:     NewAWSClient(),
-	}
-
-	if backup.Region == "" {
-		r, err := backup.Client.GetRegion()
-		if err != nil {
-			return ExitCodeAWSError, fmt.Errorf("failed to get region: %s", err.Error())
-		}
-		backup.Region = r
+		Client:     client,
 	}
 
 	if backup.InstanceID == "" {

--- a/cli.go
+++ b/cli.go
@@ -135,10 +135,14 @@ func (c *CLI) run() (int, error) {
 		return ExitCodeOK, nil
 	}
 
-	sess := NewAWSSession()
+	sess, err := NewAWSSession()
+	if err != nil {
+		return ExitCodeAWSError, fmt.Errorf("create aws session failed: %s\n", err)
+	}
+
 	client, err := NewAWSClient(sess, c.flags.region)
 	if err != nil {
-		return ExitCodeAWSError, fmt.Errorf("create aws client failed: %s", err)
+		return ExitCodeAWSError, fmt.Errorf("create aws client failed: %s\n", err)
 	}
 
 	backup := &Backup{
@@ -152,7 +156,7 @@ func (c *CLI) run() (int, error) {
 	if backup.InstanceID == "" {
 		i, err := backup.Client.GetInstanceID()
 		if err != nil {
-			return ExitCodeAWSError, fmt.Errorf("failed to get instance id: %s", err.Error())
+			return ExitCodeAWSError, fmt.Errorf("failed to get instance id: %s\n", err.Error())
 		}
 		backup.InstanceID = i
 	}
@@ -161,19 +165,19 @@ func (c *CLI) run() (int, error) {
 
 	name, err := backup.Client.GetInstanceName(ctx, backup.InstanceID)
 	if err != nil {
-		return ExitCodeAWSError, fmt.Errorf("failed to get instance name: %s", err.Error())
+		return ExitCodeAWSError, fmt.Errorf("failed to get instance name: %s\n", err.Error())
 	}
 	backup.Name = name
 
 	imageID, err := backup.Create(ctx)
 	if err != nil {
-		return ExitCodeAWSError, fmt.Errorf("failed to create backup: %s", err.Error())
+		return ExitCodeAWSError, fmt.Errorf("failed to create backup: %s\n", err.Error())
 	}
 	fmt.Fprintf(c.outStream, "create image: %s\n", imageID)
 
 	rotateImageIDs, err := backup.Rotate(ctx, imageID)
 	if err != nil {
-		return ExitCodeAWSError, fmt.Errorf("failed to rotate: %s", err.Error())
+		return ExitCodeAWSError, fmt.Errorf("failed to rotate: %s\n", err.Error())
 	}
 	fmt.Fprintf(c.outStream, "deregister images: %s\n", strings.Join(rotateImageIDs, ", "))
 


### PR DESCRIPTION
`-region` option is not effective that because specify "ap-northeast-1" in hardcord when creating a session of AWS SDK for Go.

I fixed to load region config attempt following order.

1. Load config in AWS SDK for Go
1. Get region via EC2 Metadata
1. Set "ap-northeast-1" in hardcoding as backward compatibility for previous versions
