### PR TITLE
Fix issue where not work in case of instance name tag value is non-ASCII

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -32,7 +33,21 @@ func (b *Backup) Create(ctx context.Context) (string, error) {
 	const layout = "200601021504"
 	now := time.Now().Format(layout)
 
-	imageID, err := b.Client.CreateImage(ctx, b.InstanceID, b.Name, now)
+	imageName := b.Name
+
+	isASCII := true
+	for _, c := range []byte(imageName) {
+		if c >= unicode.MaxASCII {
+			isASCII = false
+			break
+		}
+	}
+
+	if !isASCII {
+		imageName = b.InstanceID
+	}
+
+	imageID, err := b.Client.CreateImage(ctx, b.InstanceID, imageName, now)
 	if err != nil {
 		return "", err
 	}

--- a/backup.go
+++ b/backup.go
@@ -37,7 +37,7 @@ func (b *Backup) Create(ctx context.Context) (string, error) {
 
 	isASCII := true
 	for _, c := range []byte(imageName) {
-		if c >= unicode.MaxASCII {
+		if c > unicode.MaxASCII {
 			isASCII = false
 			break
 		}

--- a/backup_test.go
+++ b/backup_test.go
@@ -87,6 +87,82 @@ func TestCreate(t *testing.T) {
 	}
 }
 
+func TestCreate_InstanceNameTagValue_MultiByte(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockAWSClient := mock.NewMockAWS(mockCtrl)
+	mockAWSClient.EXPECT().CreateImage(
+		context.TODO(),
+		"i-1234567890abcdef0",
+		"i-1234567890abcdef0",
+		gomock.Any()).Return("ami-1234567890abcdef0", nil)
+	createAMITag := mockAWSClient.EXPECT().CreateTags(
+		context.TODO(),
+		"ami-1234567890abcdef0",
+		[]*ec2.Tag{
+			{Key: aws.String("BackupType"), Value: aws.String("auto")},
+			{Key: aws.String("Name"), Value: aws.String("テストサーバ")},
+			{Key: aws.String("Service"), Value: aws.String("service")},
+			{Key: aws.String("key1"), Value: aws.String("val1")},
+			{Key: aws.String("key2"), Value: aws.String("val2")},
+		}).Return(nil)
+	mockAWSClient.EXPECT().GetSnapshots(context.TODO(), "ami-1234567890abcdef0").Return(
+		[]string{"snap-1234567890abcdef0", "snap-1234567890abcdef1", "snap-1234567890abcdef2"},
+		nil)
+	createSnapTag1 := mockAWSClient.EXPECT().CreateTags(
+		context.TODO(),
+		"snap-1234567890abcdef0",
+		[]*ec2.Tag{
+			{Key: aws.String("BackupType"), Value: aws.String("auto")},
+			{Key: aws.String("Name"), Value: aws.String("テストサーバ")},
+			{Key: aws.String("Service"), Value: aws.String("service")},
+			{Key: aws.String("key1"), Value: aws.String("val1")},
+			{Key: aws.String("key2"), Value: aws.String("val2")},
+		}).Return(nil).After(createAMITag)
+	createSnapTag2 := mockAWSClient.EXPECT().CreateTags(
+		context.TODO(),
+		"snap-1234567890abcdef1",
+		[]*ec2.Tag{
+			{Key: aws.String("BackupType"), Value: aws.String("auto")},
+			{Key: aws.String("Name"), Value: aws.String("テストサーバ")},
+			{Key: aws.String("Service"), Value: aws.String("service")},
+			{Key: aws.String("key1"), Value: aws.String("val1")},
+			{Key: aws.String("key2"), Value: aws.String("val2")},
+		}).Return(nil).After(createSnapTag1)
+	mockAWSClient.EXPECT().CreateTags(
+		context.TODO(),
+		"snap-1234567890abcdef2",
+		[]*ec2.Tag{
+			{Key: aws.String("BackupType"), Value: aws.String("auto")},
+			{Key: aws.String("Name"), Value: aws.String("テストサーバ")},
+			{Key: aws.String("Service"), Value: aws.String("service")},
+			{Key: aws.String("key1"), Value: aws.String("val1")},
+			{Key: aws.String("key2"), Value: aws.String("val2")},
+		}).Return(nil).After(createSnapTag2)
+
+	backup := &Backup{
+		InstanceID: "i-1234567890abcdef0",
+		Name:       "テストサーバ",
+		Service:    "service",
+		CustomTags: []Tag{
+			{Key: "key1", Value: "val1"},
+			{Key: "key2", Value: "val2"},
+		},
+		Client: mockAWSClient,
+	}
+
+	got, err := backup.Create(context.TODO())
+	if err != nil {
+		t.Fatal("Create failed: ", err)
+	}
+
+	want := "ami-1234567890abcdef0"
+	if got != want {
+		t.Fatalf("got %s, want %s", got, want)
+	}
+}
+
 func TestRotate(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -106,6 +182,41 @@ func TestRotate(t *testing.T) {
 
 	backup := &Backup{
 		Name:       "test",
+		Service:    "service",
+		Generation: 3,
+		Client:     mockAWSClient,
+	}
+
+	got, err := backup.Rotate(context.TODO(), "ami-1234567890abcdef4")
+	if err != nil {
+		t.Fatal("Rotate failed: ", err)
+	}
+
+	want := []string{"ami-1234567890abcdef0", "ami-1234567890abcdef1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %s, want %s", got, want)
+	}
+}
+
+func TestRotate_InstanceNameTagValue_MultiByte(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockAWSClient := mock.NewMockAWS(mockCtrl)
+	mockAWSClient.EXPECT().GetImages(context.TODO(), "テストサーバ", "service").Return([]*ec2.Image{
+		{ImageId: aws.String("ami-1234567890abcdef0"), CreationDate: aws.String("2006-01-02T15:04:05.000Z"), State: aws.String("available")},
+		{ImageId: aws.String("ami-1234567890abcdef1"), CreationDate: aws.String("2006-01-02T16:04:05.000Z"), State: aws.String("available")},
+		{ImageId: aws.String("ami-1234567890abcdef2"), CreationDate: aws.String("2006-01-02T17:04:05.000Z"), State: aws.String("available")},
+		{ImageId: aws.String("ami-1234567890abcdef3"), CreationDate: aws.String("2006-01-02T18:04:05.000Z"), State: aws.String("available")},
+		{ImageId: aws.String("ami-1234567890abcdef4"), CreationDate: aws.String("2006-01-02T19:04:05.000Z"), State: aws.String("available")},
+	}, nil)
+	mockAWSClient.EXPECT().DeregisterImages(context.TODO(), []*ec2.Image{
+		{ImageId: aws.String("ami-1234567890abcdef0"), CreationDate: aws.String("2006-01-02T15:04:05.000Z"), State: aws.String("available")},
+		{ImageId: aws.String("ami-1234567890abcdef1"), CreationDate: aws.String("2006-01-02T16:04:05.000Z"), State: aws.String("available")},
+	}).Return(nil)
+
+	backup := &Backup{
+		Name:       "テストサーバ",
 		Service:    "service",
 		Generation: 3,
 		Client:     mockAWSClient,


### PR DESCRIPTION
AMI name must be specified the ASCII code.

In before this fix, possibly use the non-ASCII character in AMI name, because AMI name is built from instance name tag value.

I fixed this issue to use instance-id instead instance name tag value when it contains non-ASCII character in the instance name tag.
