### PR TITLE
Fix occur panic when ephemeral disks are attached machine image

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -245,6 +245,9 @@ func (client *AWSClient) GetSnapshots(ctx context.Context, imageID string) ([]st
 
 	var snapshots []string
 	for _, b := range result.Images[0].BlockDeviceMappings {
+		if b.Ebs == nil {
+			continue
+		}
 		snapshots = append(snapshots, *b.Ebs.SnapshotId)
 	}
 


### PR DESCRIPTION
Fix issue in 1.1.1 that occur panic when ephemeral disks are attached machine image.

```
$ go-create-image-backup
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x80a2e7]

goroutine 1 [running]:
main.(*AWSClient).GetSnapshots(0xc4201ae480, 0xa15740, 0xc4200140a8, 0xc420478980, 0x15, 0xc420470660, 0x3, 0x3, 0x0, 0x0)
	/go/src/github.com/heartbeatsjp/go-create-image-backup/aws.go:248 +0x1d7
main.(*Backup).Create(0xc4201b8420, 0xa15740, 0xc4200140a8, 0xc4201b23c0, 0x13, 0xc4204721d0, 0xb)
	/go/src/github.com/heartbeatsjp/go-create-image-backup/backup.go:85 +0x766
main.(*CLI).run(0xc4201820c0, 0xc4200101c0, 0x0, 0x0)
	/go/src/github.com/heartbeatsjp/go-create-image-backup/cli.go:172 +0x319
main.(*CLI).Run(0xc4201820c0, 0xc4200101c0, 0x1, 0x1, 0xc42006c058)
	/go/src/github.com/heartbeatsjp/go-create-image-backup/cli.go:115 +0x7b6
main.main()
	/go/src/github.com/heartbeatsjp/go-create-image-backup/main.go:7 +0xa3
```